### PR TITLE
Adding gitattributes to fix building the app on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Git on windows checks out code using CRFL by default. While you can fix this by configuring the git client users should not have to. 

This PR adds a gitattributes file to fix the problem.

To solve the problem you need to either:

Delete the repo and clone it again

...or run these commands (beware if you have made any uncommitted changes as they'll be discarded):

```bash
git checkout master
git rm --cached -r .
git reset --hard
```

Solves #150 