### PR TITLE
Adding TCP send retries

### DIFF
--- a/pipeline-ui/backend/src/api/v1/sendLogLines/sendTCPString.ts
+++ b/pipeline-ui/backend/src/api/v1/sendLogLines/sendTCPString.ts
@@ -2,17 +2,30 @@
 import net from 'net';
 import {LOGSTASH} from '../../../constants/LogstashAddress';
 import logger from '../../../util/Logger';
+import config from '../../../constants/config';
 
-function sendTCP(payload: string, port: number) {
-  const conn = net.createConnection({host: LOGSTASH, port: port}, function () {
+function sendTCP(payload: string, port: number, retries = 0) {
+  const conn = net.createConnection({host: LOGSTASH, port: port}, function() {
     conn.write(payload);
-  }).on('error', function (err) {
+  }).on('error', function(err) {
     logger.error({
       message: `Failed to send payload to ${port}.` +
         `Has all logstash pipelines started successfully?`,
       payload,
       details: err.message,
     });
+    setTimeout(() => {
+      if (retries > config.maxRetries) {
+        logger.error({
+          message: `Gave up sending payload to ${port}. Timeout reached.`,
+          payload,
+          details: err.message,
+        });
+        return;
+      }
+      logger.info(`Retrying sending payload to port ${port}`);
+      sendTCP(payload, port, ++retries);
+    }, config.retryWaitTimeSeconds * 1000);
   });
 }
 

--- a/pipeline-ui/backend/src/constants/config.ts
+++ b/pipeline-ui/backend/src/constants/config.ts
@@ -1,0 +1,4 @@
+export default {
+  maxRetries: 5,
+  retryWaitTimeSeconds: 1,
+};


### PR DESCRIPTION
In some environments the connection between the containers can be unstable because of ie. DNS resolution. This PR adds retries to make the unit tests more reliable in case of infrastructure failures.