### PR TITLE
fix: use array index as key instead of btoa() for non-Latin characters

### DIFF
--- a/pipeline-ui/frontend/src/App.tsx
+++ b/pipeline-ui/frontend/src/App.tsx
@@ -62,9 +62,9 @@ function App() {
       <Grid item xs={12}>
         {
           logStashResult.length ?
-            logStashResult.map((res) => {
+            logStashResult.map((res, index) => {
               return (
-                <Result key={btoa(res)} result={res}/>
+                <Result key={index} result={res}/>
               );
             }) :
             ''


### PR DESCRIPTION
## Problem
`btoa()` throws `InvalidCharacterError` when encoding strings containing non-Latin1 characters (Unicode > 255), breaking the rendering of log results with non-Latin characters.

## Solution
Replaced `btoa(res)` with array `index` for React keys in the logStashResult map function.

## Changes
- Changed `key={btoa(res)}` to `key={index}` in App.tsx line 73
- Added `index` parameter to `.map()` callback

## Testing
- ✅ Compiles without errors
- ✅ Works with Cyrillic characters from Logstash output
- ✅ No InvalidCharacterError in browser console

## Related
Fixes issue with syslog messages containing non-Latin characters.
